### PR TITLE
Update auth domain

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,33 @@
 
 -   Removed relationship links from responses by default
 
+### ⚠️ Breaking changes
+
+-   Login data have to be sent in `data.attributes` instead of directly in the root of the request body.
+
+    **Before:**
+
+    ```json
+    {
+        "email": "{email}"
+        "password": "{password}"
+    }
+    ```
+
+    **After:**
+
+    ```json
+    {
+        "data": {
+            "type": "auth",
+            "attributes": {
+                "email": "{email}",
+                "password": "{password}"
+            }
+        }
+    }
+    ```
+
 ## 1.0.0-beta.3
 
 ### Changes

--- a/src/Domain/Auth/Http/Controllers/PasswordResetLinkController.php
+++ b/src/Domain/Auth/Http/Controllers/PasswordResetLinkController.php
@@ -28,7 +28,7 @@ class PasswordResetLinkController extends Controller implements PasswordResetLin
         return DataResponse::make(null)
             ->withMeta([
                 'message' => __('auth.password_reset.confirmation'),
-                'success' => $success,
+                // 'success' => $success,
             ]);
     }
 

--- a/src/Domain/Auth/JsonApi/V1/LoginRequest.php
+++ b/src/Domain/Auth/JsonApi/V1/LoginRequest.php
@@ -2,9 +2,12 @@
 
 namespace Dystcz\LunarApi\Domain\Auth\JsonApi\V1;
 
-use Illuminate\Foundation\Http\FormRequest;
+use Dystcz\LunarApi\Facades\LunarApi;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Validation\Validator;
+use LaravelJsonApi\Laravel\Http\Requests\ResourceRequest;
 
-class LoginRequest extends FormRequest
+class LoginRequest extends ResourceRequest
 {
     /**
      * Determine if the user is authorized to make this request.
@@ -48,5 +51,23 @@ class LoginRequest extends FormRequest
             'password.required' => __('lunar-api::validations.auth.password.required'),
             'password.string' => __('lunar-api::validations.auth.password.string'),
         ];
+    }
+
+    /**
+     * Configure the validator instance.
+     */
+    public function withValidator(Validator $validator): void
+    {
+        $validator->after(function (Validator $validator) {
+            if (! Auth::guard(LunarApi::getAuthGuard())->attempt([
+                'email' => $this->input('data.attributes.email'),
+                'password' => $this->input('data.attributes.password'),
+            ])) {
+                $validator->errors()->add(
+                    'password',
+                    __('lunar-api::validations.auth.attempt.failed'),
+                );
+            }
+        });
     }
 }

--- a/tests/Feature/Domain/Auth/JsonApi/V1/LoginTest.php
+++ b/tests/Feature/Domain/Auth/JsonApi/V1/LoginTest.php
@@ -57,7 +57,9 @@ it('can log in a user', function () {
         ->withData($data)
         ->post(serverUrl('/auth/-actions/login'));
 
-    $response->assertSuccessful();
+    $response
+        ->assertSuccessful()
+        ->assertFetchedOne($user);
 });
 
 it('can return a user with customers included after login', function () {
@@ -85,5 +87,6 @@ it('can return a user with customers included after login', function () {
 
     $response
         ->assertSuccessful()
+        ->assertFetchedOne($user)
         ->assertIsIncluded('customers', $user->customers->first());
 });

--- a/tests/Feature/Domain/Auth/JsonApi/V1/LoginTest.php
+++ b/tests/Feature/Domain/Auth/JsonApi/V1/LoginTest.php
@@ -1,5 +1,6 @@
 <?php
 
+use Dystcz\LunarApi\Domain\Customers\Models\Customer;
 use Dystcz\LunarApi\Domain\Users\Models\User;
 use Dystcz\LunarApi\Tests\TestCase;
 use Illuminate\Foundation\Testing\RefreshDatabase;
@@ -8,17 +9,81 @@ use Illuminate\Support\Facades\Hash;
 uses(TestCase::class, RefreshDatabase::class)
     ->group('auth');
 
+it('cannot log in a user with wrong credentials', function () {
+    /** @var TestCase $this */
+    $user = User::factory()->create([
+        'password' => Hash::make('password'),
+    ]);
+
+    $data = [
+        'type' => 'auth',
+        'attributes' => [
+            'email' => $user->email,
+            'password' => 'swag',
+        ],
+    ];
+
+    $response = $this
+        ->jsonApi()
+        ->expects('users')
+        ->withData($data)
+        ->post(serverUrl('/auth/-actions/login'));
+
+    $response
+        ->assertStatus(422)
+        ->assertErrorStatus([
+            'detail' => __('lunar-api::validations.auth.attempt.failed'),
+            'status' => '422',
+        ]);
+});
+
 it('can log in a user', function () {
     /** @var TestCase $this */
     $user = User::factory()->create([
         'password' => Hash::make('password'),
     ]);
 
-    $response = $this
-        ->post(serverUrl('/auth/-actions/login'), [
+    $data = [
+        'type' => 'auth',
+        'attributes' => [
             'email' => $user->email,
             'password' => 'password',
-        ]);
+        ],
+    ];
+
+    $response = $this
+        ->jsonApi()
+        ->expects('users')
+        ->withData($data)
+        ->post(serverUrl('/auth/-actions/login'));
 
     $response->assertSuccessful();
+});
+
+it('can return a user with customers included after login', function () {
+    /** @var TestCase $this */
+    $user = User::factory()
+        ->has(Customer::factory(), 'customers')
+        ->create([
+            'password' => Hash::make('password'),
+        ]);
+
+    $data = [
+        'type' => 'auth',
+        'attributes' => [
+            'email' => $user->email,
+            'password' => 'password',
+        ],
+    ];
+
+    $response = $this
+        ->jsonApi()
+        ->expects('users')
+        ->withData($data)
+        ->includePaths('customers')
+        ->post(serverUrl('/auth/-actions/login'));
+
+    $response
+        ->assertSuccessful()
+        ->assertIsIncluded('customers', $user->customers->first());
 });

--- a/tests/Feature/Domain/Auth/JsonApi/V1/ReadLoggedInUserTest.php
+++ b/tests/Feature/Domain/Auth/JsonApi/V1/ReadLoggedInUserTest.php
@@ -1,0 +1,48 @@
+<?php
+
+use Dystcz\LunarApi\Domain\Customers\Models\Customer;
+use Dystcz\LunarApi\Domain\Users\Models\User;
+use Dystcz\LunarApi\Tests\TestCase;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Hash;
+
+uses(TestCase::class, RefreshDatabase::class)
+    ->group('auth');
+
+it('can get currently logged in user', function () {
+    /** @var TestCase $this */
+    $user = User::factory()->create([
+        'password' => Hash::make('password'),
+    ]);
+
+    $response = $this
+        ->actingAs($user)
+        ->jsonApi()
+        ->expects('users')
+        ->get(serverUrl('/auth/-actions/me'));
+
+    $response
+        ->assertSuccessful()
+        ->assertFetchedOne($user);
+});
+
+it('can get currently logged in user with customers included', function () {
+    /** @var TestCase $this */
+    $user = User::factory()
+        ->has(Customer::factory(), 'customers')
+        ->create([
+            'password' => Hash::make('password'),
+        ]);
+
+    $response = $this
+        ->actingAs($user)
+        ->jsonApi()
+        ->expects('users')
+        ->includePaths('customers')
+        ->get(serverUrl('/auth/-actions/me'));
+
+    $response
+        ->assertSuccessful()
+        ->assertFetchedOne($user)
+        ->assertIsIncluded('customers', $user->customers->first());
+});

--- a/tests/Feature/Domain/Auth/JsonApi/V1/ResetPasswordTest.php
+++ b/tests/Feature/Domain/Auth/JsonApi/V1/ResetPasswordTest.php
@@ -39,6 +39,6 @@ it('can send password reset links to users', function () {
     $response->assertFetchedNull()
         ->assertExactMeta([
             'message' => __('auth.password_reset.confirmation'),
-            'success' => true,
+            // 'success' => true,
         ]);
 });

--- a/tests/Feature/Domain/CartLines/JsonApi/V1/CreateCartLineTest.php
+++ b/tests/Feature/Domain/CartLines/JsonApi/V1/CreateCartLineTest.php
@@ -77,10 +77,16 @@ it('can associate existing cart to users after they log in', function () {
     ]);
 
     $response = $this
-        ->post(serverUrl('/auth/-actions/login'), [
-            'email' => $user->email,
-            'password' => 'password',
-        ]);
+        ->jsonApi()
+        ->expects('users')
+        ->withData([
+            'type' => 'auth',
+            'attributes' => [
+                'email' => $user->email,
+                'password' => 'password',
+            ],
+        ])
+        ->post(serverUrl('/auth/-actions/login'));
 
     /** @var ProductVariant $purchasable */
     $purchasable = ProductVariant::factory()
@@ -104,10 +110,16 @@ it('can associate existing cart to users after they log in', function () {
     ];
 
     $response = $this
-        ->post(serverUrl('/auth/-actions/login'), [
-            'email' => $user->email,
-            'password' => 'password',
-        ]);
+        ->jsonApi()
+        ->expects('users')
+        ->withData([
+            'type' => 'auth',
+            'attributes' => [
+                'email' => $user->email,
+                'password' => 'password',
+            ],
+        ])
+        ->post(serverUrl('/auth/-actions/login'));
 
     $cart = $cart->fresh();
 


### PR DESCRIPTION
### ⚠️ Breaking changes

-   Login data have to be sent in `data.attributes` instead of directly in the root of the request body.

    **Before:**

    ```json
    {
        "email": "{email}"
        "password": "{password}"
    }
    ```

    **After:**

    ```json
    {
        "data": {
            "type": "auth",
            "attributes": {
                "email": "{email}",
                "password": "{password}"
            }
        }
    }
    ```