### PR TITLE
Add cart shipping option endpoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,33 +6,13 @@
 
 -   Removed relationship links from responses by default
 -   Changed price taxation config to `lunar.pricing.stored_inclusive_of_tax` from `lunar-api.general.taxation.prices_with_default_tax`
+-   Added endpoints to set and unset shipping options directly to / from current session cart
+    ([#210](https://github.com/dystcz/dystore-api/pull/210))
 
 ### ⚠️ Breaking changes
 
 -   Login data have to be sent in `data.attributes` instead of directly in the root of the request body.
-
-    **Before:**
-
-    ```json
-    {
-        "email": "{email}"
-        "password": "{password}"
-    }
-    ```
-
-    **After:**
-
-    ```json
-    {
-        "data": {
-            "type": "auth",
-            "attributes": {
-                "email": "{email}",
-                "password": "{password}"
-            }
-        }
-    }
-    ```
+    ([#205](https://github.com/dystcz/dystore-api/pull/205))
 
 ## 1.0.0-beta.3
 

--- a/lang/cs/validations.php
+++ b/lang/cs/validations.php
@@ -80,6 +80,9 @@ return [
     ],
 
     'carts' => [
+        'session' => [
+            'exists' => 'Nákupní košík nebyl nalezen.',
+        ],
         'create_user' => [
             'boolean' => 'Pole vytvořit uživatele musí být logická hodnota.',
         ],

--- a/lang/en/validations.php
+++ b/lang/en/validations.php
@@ -80,6 +80,9 @@ return [
     ],
 
     'carts' => [
+        'session' => [
+            'exists' => 'There is no cart in the session.',
+        ],
         'create_user' => [
             'boolean' => 'Create user field must be a boolean.',
         ],

--- a/src/Domain/Carts/Contracts/CartShippingOptionController.php
+++ b/src/Domain/Carts/Contracts/CartShippingOptionController.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Dystcz\LunarApi\Domain\Carts\Contracts;
+
+/**
+ * @see \Dystcz\LunarApi\Domain\Carts\Http\Controllers\CartShippingOptionController
+ */
+interface CartShippingOptionController {}

--- a/src/Domain/Carts/Http/Controllers/CartShippingOptionController.php
+++ b/src/Domain/Carts/Http/Controllers/CartShippingOptionController.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace Dystcz\LunarApi\Domain\Carts\Http\Controllers;
+
+use Dystcz\LunarApi\Base\Controller;
+use Dystcz\LunarApi\Domain\CartAddresses\JsonApi\V1\CartAddressSchema;
+use Dystcz\LunarApi\Domain\Carts\Contracts\CartShippingOptionController as CartShippingOptionControllerContract;
+use Dystcz\LunarApi\Domain\Carts\Contracts\CurrentSessionCart;
+use Dystcz\LunarApi\Domain\Carts\JsonApi\V1\SetShippingOptionRequest;
+use Dystcz\LunarApi\Domain\Carts\JsonApi\V1\UnsetShippingOptionRequest;
+use Dystcz\LunarApi\Domain\Carts\Models\Cart;
+use LaravelJsonApi\Core\Responses\DataResponse;
+
+class CartShippingOptionController extends Controller implements CartShippingOptionControllerContract
+{
+    /**
+     * Set shipping option to cart.
+     */
+    public function setShippingOption(
+        CartAddressSchema $schema,
+        SetShippingOptionRequest $request,
+        ?CurrentSessionCart $cart,
+    ): DataResponse {
+        /** @var Cart $cart */
+        $this->authorize('updateShippingOption', $cart);
+
+        $cartAddress = $cart
+            ->addresses()
+            ->where('type', $request->input('data.attributes.address_type'))
+            ->firstOrFail();
+
+        // Set shipping option
+        $cartAddress->update([
+            'shipping_option' => $request->input('data.attributes.shipping_option'),
+        ]);
+
+        $model = $schema
+            ->repository()
+            ->queryOne($cartAddress)
+            ->withRequest($request)
+            ->first();
+
+        return DataResponse::make($model)
+            ->didntCreate();
+    }
+
+    /**
+     * Unset shipping option from cart.
+     */
+    public function unsetShippingOption(
+        CartAddressSchema $schema,
+        UnsetShippingOptionRequest $request,
+        ?CurrentSessionCart $cart,
+    ): DataResponse {
+        /** @var Cart $cart */
+        $this->authorize('updateShippingOption', $cart);
+
+        $cartAddress = $cart
+            ->addresses()
+            ->where('type', $request->input('data.attributes.address_type'))
+            ->firstOrFail();
+
+        // Unset shipping option
+        $cartAddress->update([
+            'shipping_option' => null,
+        ]);
+
+        $model = $schema
+            ->repository()
+            ->queryOne($cartAddress)
+            ->withRequest($request)
+            ->first();
+
+        return DataResponse::make($model)
+            ->didntCreate();
+    }
+}

--- a/src/Domain/Carts/Http/Routing/CartRouteGroup.php
+++ b/src/Domain/Carts/Http/Routing/CartRouteGroup.php
@@ -5,6 +5,7 @@ namespace Dystcz\LunarApi\Domain\Carts\Http\Routing;
 use Dystcz\LunarApi\Domain\Carts\Contracts\CartCouponsController;
 use Dystcz\LunarApi\Domain\Carts\Contracts\CartPaymentOptionController;
 use Dystcz\LunarApi\Domain\Carts\Contracts\CartsController;
+use Dystcz\LunarApi\Domain\Carts\Contracts\CartShippingOptionController;
 use Dystcz\LunarApi\Domain\Carts\Contracts\CheckoutCartController;
 use Dystcz\LunarApi\Domain\Carts\Contracts\ClearUserCartController;
 use Dystcz\LunarApi\Domain\Carts\Contracts\CreateEmptyCartAddressesController;
@@ -50,6 +51,13 @@ class CartRouteGroup extends RouteGroup
                     ->only('')
                     ->actions('-actions', function (ActionRegistrar $actions) {
                         $actions->post('create-empty-addresses');
+                    });
+
+                $server->resource($this->getPrefix(), CartShippingOptionController::class)
+                    ->only('')
+                    ->actions('-actions', function (ActionRegistrar $actions) {
+                        $actions->post('set-shipping-option');
+                        $actions->post('unset-shipping-option');
                     });
 
                 $server->resource($this->getPrefix(), CheckoutCartController::class)

--- a/src/Domain/Carts/JsonApi/V1/CartSchema.php
+++ b/src/Domain/Carts/JsonApi/V1/CartSchema.php
@@ -125,14 +125,21 @@ class CartSchema extends Schema
 
             Str::make('payment_option'),
 
-            // Custom fields (not in the database)
+            // NOTE: Attributes used for setting shipping options to current session cart
+            Str::make('shipping_option')
+                ->hidden(),
+
+            Str::make('address_type')
+                ->hidden(),
+
+            // NOTE: Attributes used for determining if user should be created during checkout
             Boolean::make('create_user')
                 ->hidden(),
 
-            ArrayHash::make('meta'),
-
             Boolean::make('agree')
                 ->hidden(),
+
+            ArrayHash::make('meta'),
 
             HasOne::make('order', 'draftOrder')
                 ->type(SchemaType::get(Order::class))

--- a/src/Domain/Carts/JsonApi/V1/SetShippingOptionRequest.php
+++ b/src/Domain/Carts/JsonApi/V1/SetShippingOptionRequest.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace Dystcz\LunarApi\Domain\Carts\JsonApi\V1;
+
+use Dystcz\LunarApi\Domain\Addresses\Http\Enums\AddressType;
+use Illuminate\Validation\Rule;
+use LaravelJsonApi\Laravel\Http\Requests\ResourceRequest;
+
+class SetShippingOptionRequest extends ResourceRequest
+{
+    /**
+     * Get the validation rules for the resource.
+     *
+     * @return array<string,array<int,mixed>>
+     */
+    public function rules(): array
+    {
+        return [
+            'shipping_option' => [
+                'required',
+                'string',
+            ],
+            'address_type' => [
+                'required',
+                'string',
+                Rule::in([
+                    AddressType::SHIPPING->value,
+                    AddressType::BILLING->value,
+                ]),
+            ],
+        ];
+    }
+
+    /**
+     * Get custom messages for validator errors.
+     *
+     * @return array<string,string>
+     */
+    public function messages(): array
+    {
+        return [
+            'shipping_option.required' => __('lunar-api::validations.shipping.set_shipping_option.shipping_option.required'),
+            'shipping_option.string' => __('lunar-api::validations.shipping.set_shipping_option.shipping_option.string'),
+            'address_type.required' => __('lunar-api::validations.cart_addresses.address_type.required'),
+            'address_type.string' => __('lunar-api::validations.cart_addresses.address_type.string'),
+            'address_type.in' => __('lunar-api::validations.cart_addresses.address_type.in', [
+                'types' => implode(', ', [
+                    AddressType::SHIPPING->value,
+                    AddressType::BILLING->value,
+                ]),
+            ]),
+        ];
+    }
+}

--- a/src/Domain/Carts/JsonApi/V1/UnsetShippingOptionRequest.php
+++ b/src/Domain/Carts/JsonApi/V1/UnsetShippingOptionRequest.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace Dystcz\LunarApi\Domain\Carts\JsonApi\V1;
+
+use Dystcz\LunarApi\Domain\Addresses\Http\Enums\AddressType;
+use Dystcz\LunarApi\Domain\Carts\Rules\CartInSessionExists;
+use Illuminate\Validation\Rule;
+use LaravelJsonApi\Laravel\Http\Requests\ResourceRequest;
+
+class UnsetShippingOptionRequest extends ResourceRequest
+{
+    /**
+     * Get the validation rules for the resource.
+     *
+     * @return array<string,array<int,mixed>>
+     */
+    public function rules(): array
+    {
+        return [
+            'cart' => [
+                new CartInSessionExists,
+            ],
+            'address_type' => [
+                'required',
+                'string',
+                Rule::in([
+                    AddressType::SHIPPING->value,
+                    AddressType::BILLING->value,
+                ]),
+            ],
+        ];
+    }
+
+    /**
+     * Get custom messages for validator errors.
+     *
+     * @return array<string,string>
+     */
+    public function messages(): array
+    {
+        return [
+            'address_type.required' => __('lunar-api::validations.cart_addresses.address_type.required'),
+            'address_type.string' => __('lunar-api::validations.cart_addresses.address_type.string'),
+            'address_type.in' => __('lunar-api::validations.cart_addresses.address_type.in', [
+                'types' => implode(', ', [
+                    AddressType::SHIPPING->value,
+                    AddressType::BILLING->value,
+                ]),
+            ]),
+        ];
+    }
+}

--- a/src/Domain/Carts/Policies/CartPolicy.php
+++ b/src/Domain/Carts/Policies/CartPolicy.php
@@ -247,6 +247,14 @@ class CartPolicy
     /**
      * Determine whether the user can update payment option.
      */
+    public function updateShippingOption(?Authenticatable $user, CartContract $cart): bool
+    {
+        return $this->check($user, $cart);
+    }
+
+    /**
+     * Determine whether the user can update payment option.
+     */
     public function updatePaymentOption(?Authenticatable $user, CartContract $cart): bool
     {
         return $this->check($user, $cart);

--- a/src/Domain/Carts/Rules/CartInSessionExists.php
+++ b/src/Domain/Carts/Rules/CartInSessionExists.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Dystcz\LunarApi\Domain\Carts\Rules;
+
+use Closure;
+use Dystcz\LunarApi\Domain\Carts\Contracts\CurrentSessionCart;
+use Illuminate\Contracts\Validation\ValidationRule;
+use Illuminate\Support\Facades\App;
+use Lunar\Models\Contracts\Cart as CartContract;
+
+class CartInSessionExists implements ValidationRule
+{
+    protected ?CartContract $cart;
+
+    public function __construct(
+    ) {
+        $this->cart = App::make(CurrentSessionCart::class);
+    }
+
+    /**
+     * All of the data under validation.
+     *
+     * @var array<string, mixed>
+     */
+    protected array $data = [];
+
+    /**
+     * Run the validation rule.
+     */
+    public function validate(string $attribute, mixed $value, Closure $fail): void
+    {
+        if (! $this->cart instanceof CartContract) {
+            $fail(__('validation.carts.session.exists'));
+        }
+    }
+}

--- a/src/LunarApiServiceProvider.php
+++ b/src/LunarApiServiceProvider.php
@@ -296,6 +296,11 @@ class LunarApiServiceProvider extends ServiceProvider
     {
         $controllers = [
             \Dystcz\LunarApi\Domain\Addresses\Contracts\AddressesController::class => \Dystcz\LunarApi\Domain\Addresses\Http\Controllers\AddressesController::class,
+            \Dystcz\LunarApi\Domain\Auth\Contracts\AuthController::class => \Dystcz\LunarApi\Domain\Auth\Http\Controllers\AuthController::class,
+            \Dystcz\LunarApi\Domain\Auth\Contracts\AuthUserOrdersController::class => \Dystcz\LunarApi\Domain\Auth\Http\Controllers\AuthUserOrdersController::class,
+            \Dystcz\LunarApi\Domain\Auth\Contracts\NewPasswordController::class => \Dystcz\LunarApi\Domain\Auth\Http\Controllers\NewPasswordController::class,
+            \Dystcz\LunarApi\Domain\Auth\Contracts\PasswordResetLinkController::class => \Dystcz\LunarApi\Domain\Auth\Http\Controllers\PasswordResetLinkController::class,
+            \Dystcz\LunarApi\Domain\Auth\Contracts\RegisterUserWithoutPasswordController::class => \Dystcz\LunarApi\Domain\Auth\Http\Controllers\RegisterUserWithoutPasswordController::class,
             \Dystcz\LunarApi\Domain\Brands\Contracts\BrandsController::class => \Dystcz\LunarApi\Domain\Brands\Http\Controllers\BrandsController::class,
             \Dystcz\LunarApi\Domain\CartAddresses\Contracts\CartAddressShippingOptionController::class => \Dystcz\LunarApi\Domain\CartAddresses\Http\Controllers\CartAddressShippingOptionController::class,
             \Dystcz\LunarApi\Domain\CartAddresses\Contracts\CartAddressesController::class => \Dystcz\LunarApi\Domain\CartAddresses\Http\Controllers\CartAddressesController::class,
@@ -304,6 +309,7 @@ class LunarApiServiceProvider extends ServiceProvider
             \Dystcz\LunarApi\Domain\CartLines\Contracts\CartLinesController::class => \Dystcz\LunarApi\Domain\CartLines\Http\Controllers\CartLinesController::class,
             \Dystcz\LunarApi\Domain\Carts\Contracts\CartCouponsController::class => \Dystcz\LunarApi\Domain\Carts\Http\Controllers\CartCouponsController::class,
             \Dystcz\LunarApi\Domain\Carts\Contracts\CartPaymentOptionController::class => \Dystcz\LunarApi\Domain\Carts\Http\Controllers\CartPaymentOptionController::class,
+            \Dystcz\LunarApi\Domain\Carts\Contracts\CartShippingOptionController::class => \Dystcz\LunarApi\Domain\Carts\Http\Controllers\CartShippingOptionController::class,
             \Dystcz\LunarApi\Domain\Carts\Contracts\CartsController::class => \Dystcz\LunarApi\Domain\Carts\Http\Controllers\CartsController::class,
             \Dystcz\LunarApi\Domain\Carts\Contracts\CheckoutCartController::class => \Dystcz\LunarApi\Domain\Carts\Http\Controllers\CheckoutCartController::class,
             \Dystcz\LunarApi\Domain\Carts\Contracts\ClearUserCartController::class => \Dystcz\LunarApi\Domain\Carts\Http\Controllers\ClearUserCartController::class,
@@ -328,13 +334,8 @@ class LunarApiServiceProvider extends ServiceProvider
             \Dystcz\LunarApi\Domain\ShippingOptions\Contracts\ShippingOptionsController::class => \Dystcz\LunarApi\Domain\ShippingOptions\Http\Controllers\ShippingOptionsController::class,
             \Dystcz\LunarApi\Domain\Tags\Contracts\TagsController::class => \Dystcz\LunarApi\Domain\Tags\Http\Controllers\TagsController::class,
             \Dystcz\LunarApi\Domain\Urls\Contracts\UrlsController::class => \Dystcz\LunarApi\Domain\Urls\Http\Controllers\UrlsController::class,
-            \Dystcz\LunarApi\Domain\Users\Contracts\UsersController::class => \Dystcz\LunarApi\Domain\Users\Http\Controllers\UsersController::class,
             \Dystcz\LunarApi\Domain\Users\Contracts\ChangePasswordController::class => \Dystcz\LunarApi\Domain\Users\Http\Controllers\ChangePasswordController::class,
-            \Dystcz\LunarApi\Domain\Auth\Contracts\AuthUserOrdersController::class => \Dystcz\LunarApi\Domain\Auth\Http\Controllers\AuthUserOrdersController::class,
-            \Dystcz\LunarApi\Domain\Auth\Contracts\RegisterUserWithoutPasswordController::class => \Dystcz\LunarApi\Domain\Auth\Http\Controllers\RegisterUserWithoutPasswordController::class,
-            \Dystcz\LunarApi\Domain\Auth\Contracts\AuthController::class => \Dystcz\LunarApi\Domain\Auth\Http\Controllers\AuthController::class,
-            \Dystcz\LunarApi\Domain\Auth\Contracts\PasswordResetLinkController::class => \Dystcz\LunarApi\Domain\Auth\Http\Controllers\PasswordResetLinkController::class,
-            \Dystcz\LunarApi\Domain\Auth\Contracts\NewPasswordController::class => \Dystcz\LunarApi\Domain\Auth\Http\Controllers\NewPasswordController::class,
+            \Dystcz\LunarApi\Domain\Users\Contracts\UsersController::class => \Dystcz\LunarApi\Domain\Users\Http\Controllers\UsersController::class,
         ];
 
         foreach ($controllers as $abstract => $concrete) {

--- a/tests/Feature/Domain/Cart/JsonApi/V1/SetShippingOptionTest.php
+++ b/tests/Feature/Domain/Cart/JsonApi/V1/SetShippingOptionTest.php
@@ -1,0 +1,126 @@
+<?php
+
+use Dystcz\LunarApi\Domain\Addresses\Http\Enums\AddressType;
+use Dystcz\LunarApi\Domain\CartAddresses\Models\CartAddress;
+use Dystcz\LunarApi\Domain\Carts\Models\Cart;
+use Dystcz\LunarApi\Tests\TestCase;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\App;
+use Illuminate\Support\Facades\Config;
+use Lunar\Base\CartSessionInterface;
+use Lunar\Facades\ShippingManifest;
+
+uses(TestCase::class, RefreshDatabase::class);
+
+beforeEach(function () {
+    /** @var TestCase $this */
+    $this->cartSession = App::make(CartSessionInterface::class);
+
+    Config::set('lunar.cart_session.auto_create', false);
+})->group('carts', 'shipping_options');
+
+afterEach(function () {
+    /** @var TestCase $this */
+    $this->cartSession->forget();
+});
+
+test('users can set a shipping option to current session cart', function () {
+    /** @var TestCase $this */
+    $cart = Cart::factory()->create();
+
+    $cartAddress = CartAddress::factory()->for($cart)->create();
+
+    $shippingOption = ShippingManifest::getOptions($cart)->first();
+
+    $this->cartSession->use($cart);
+
+    $data = [
+        'type' => 'carts',
+        'attributes' => [
+            'address_type' => AddressType::SHIPPING,
+            'shipping_option' => $shippingOption->identifier,
+        ],
+    ];
+
+    $response = $this
+        ->jsonApi()
+        ->expects('cart_addresses')
+        ->withData($data)
+        ->post(serverUrl('/carts/-actions/set-shipping-option'));
+
+    $response
+        ->assertSuccessful()
+        ->assertFetchedOne($cart);
+
+    $this->assertDatabaseHas($cartAddress->getTable(), [
+        'id' => $cartAddress->getRouteKey(),
+        'shipping_option' => $shippingOption->identifier,
+    ]);
+
+    expect($cartAddress->fresh()->shipping_option)->toBe($data['attributes']['shipping_option']);
+});
+
+it('validates cart address type and shipping option attribute when setting shipping option to cart', function () {
+    /** @var TestCase $this */
+    $cart = Cart::factory()->create();
+
+    $cartAddress = CartAddress::factory()->for($cart)->create();
+
+    $shippingOption = ShippingManifest::getOptions($cart)->first();
+
+    $this->cartSession->use($cart);
+
+    $data = [
+        'type' => 'carts',
+        'attributes' => [
+            'address_type' => null,
+            'shipping_option' => null,
+        ],
+    ];
+
+    $response = $this
+        ->jsonApi()
+        ->expects('cart_addresses')
+        ->withData($data)
+        ->post(serverUrl('/carts/-actions/set-shipping-option'));
+
+    $response->assertErrors(422, [
+        [
+            'detail' => __('lunar-api::validations.shipping.set_shipping_option.shipping_option.required'),
+            'status' => '422',
+        ],
+        [
+            'detail' => __('lunar-api::validations.cart_addresses.address_type.required'),
+            'status' => '422',
+        ],
+    ]);
+});
+
+it('throws authorization exception when cart does not exist in session', function () {
+    /** @var TestCase $this */
+    $cart = Cart::factory()->create();
+
+    $cartAddress = CartAddress::factory()->for($cart)->create();
+
+    $shippingOption = ShippingManifest::getOptions($cart)->first();
+
+    $data = [
+        'type' => 'carts',
+        'attributes' => [
+            'address_type' => AddressType::SHIPPING,
+            'shipping_option' => $shippingOption->identifier,
+        ],
+    ];
+
+    $response = $this
+        ->jsonApi()
+        ->expects('cart_addresses')
+        ->withData($data)
+        ->post(serverUrl('/carts/-actions/set-shipping-option'));
+
+    $response->assertErrorStatus([
+        'detail' => 'This action is unauthorized.',
+        'status' => '403',
+        'title' => 'Forbidden',
+    ]);
+});

--- a/tests/Feature/Domain/Cart/JsonApi/V1/UnsetShippingOptionTest.php
+++ b/tests/Feature/Domain/Cart/JsonApi/V1/UnsetShippingOptionTest.php
@@ -1,0 +1,112 @@
+<?php
+
+use Dystcz\LunarApi\Domain\Addresses\Http\Enums\AddressType;
+use Dystcz\LunarApi\Domain\CartAddresses\Models\CartAddress;
+use Dystcz\LunarApi\Domain\Carts\Models\Cart;
+use Dystcz\LunarApi\Tests\TestCase;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\App;
+use Illuminate\Support\Facades\Config;
+use Lunar\Base\CartSessionInterface;
+use Lunar\Facades\ShippingManifest;
+
+uses(TestCase::class, RefreshDatabase::class);
+
+beforeEach(function () {
+    /** @var TestCase $this */
+    $this->cartSession = App::make(CartSessionInterface::class);
+
+    Config::set('lunar.cart_session.auto_create', false);
+})->group('carts', 'shipping_options');
+
+afterEach(function () {
+    /** @var TestCase $this */
+    $this->cartSession->forget();
+});
+
+it('can unset a shipping option from current session cart', function () {
+    /** @var TestCase $this */
+    $cart = Cart::factory()->create();
+
+    $shippingOption = ShippingManifest::getOptions($cart)->first();
+
+    $cartAddress = CartAddress::factory()->for($cart)->create([
+        'shipping_option' => $shippingOption->identifier,
+    ]);
+
+    $this->cartSession->use($cart);
+
+    $data = [
+        'type' => 'carts',
+        'attributes' => [
+            'address_type' => AddressType::SHIPPING,
+        ],
+    ];
+
+    $response = $this
+        ->jsonApi()
+        ->expects('cart_addresses')
+        ->withData($data)
+        ->post(serverUrl('/carts/-actions/unset-shipping-option'));
+
+    $response
+        ->assertSuccessful()
+        ->assertFetchedOne($cart);
+
+    $this->assertDatabaseHas($cartAddress->getTable(), [
+        'id' => $cartAddress->getRouteKey(),
+        'shipping_option' => null,
+    ]);
+
+    expect($cartAddress->fresh()->shipping_option)->toBe(null);
+});
+
+it('validates cart address type and shipping option attribute when unsetting shipping option from a cart', function () {
+    /** @var TestCase $this */
+    $cart = Cart::factory()->create();
+
+    $this->cartSession->use($cart);
+
+    $data = [
+        'type' => 'carts',
+        'attributes' => [
+            'address_type' => null,
+            'shipping_option' => null,
+        ],
+    ];
+
+    $response = $this
+        ->jsonApi()
+        ->expects('cart_addresses')
+        ->withData($data)
+        ->post(serverUrl('/carts/-actions/unset-shipping-option'));
+
+    $response->assertErrors(422, [
+        [
+            'detail' => __('lunar-api::validations.cart_addresses.address_type.required'),
+            'status' => '422',
+        ],
+    ]);
+});
+
+it('throws authorization exception when cart does not exist in session', function () {
+    /** @var TestCase $this */
+    $data = [
+        'type' => 'carts',
+        'attributes' => [
+            'address_type' => AddressType::SHIPPING,
+        ],
+    ];
+
+    $response = $this
+        ->jsonApi()
+        ->expects('cart_addresses')
+        ->withData($data)
+        ->post(serverUrl('/carts/-actions/unset-shipping-option'));
+
+    $response->assertErrorStatus([
+        'detail' => 'This action is unauthorized.',
+        'status' => '403',
+        'title' => 'Forbidden',
+    ]);
+});


### PR DESCRIPTION
Set shipping option directly on current session cart by calling `/api/v1/carts/-actions/set-shipping-option` with:
```php
[
    'type' => 'carts',
    'attributes' => [
        'address_type' => AddressType::SHIPPING, // shipping / billing
        'shipping_option' => $shippingOptionIdentifier,
    ],
];
```

Unset shipping option directly from current session cart by calling `/api/v1/carts/-actions/unset-shipping-option` with:
```php
[
    'type' => 'carts',
    'attributes' => [
        'address_type' => AddressType::SHIPPING, // shipping / billing
    ],
];
```